### PR TITLE
reboot on MQTT connect failure

### DIFF
--- a/hoera10jaar.ino
+++ b/hoera10jaar.ino
@@ -437,6 +437,7 @@ void reconnect_mqtt() {
       Serial.printf("mislukt, rc=%d\n", mqtt.state());
       all(5000, true, true);
       all(1, false, false);
+      ESP.restart(); // voor 'badge boot sneller dan dat de MQTT online komt'
     }
   }
 }


### PR DESCRIPTION
```
21:18:45 -!- hepb [~hepb@smurfnet-g10.4rn.2itm2e.IP] has quit [Quit: ]
22:21:51 < flimpie1> de revspace spacestate pcb die aan de koelkast hangt is stuk
22:21:58 < flimpie1> staat rood te knipperen op alle liedjes
22:22:03 < flimpie1> ledjes
22:28:54 <@FooBar> even rebooten is meestal voldoende
22:29:03 <@FooBar> dan kon hij de mqtt server nit vinden
22:29:38 <@FooBar> thuis ook altijd als de router reboot
22:41:45 -bitlair:#bitlair- Doorduino: lockstate closed
22:42:14 -bitlair:#bitlair- Alarm event: CL002 -- Closing Report: System armed, normal
22:45:39 <@buZz> zou toch niet zoveel moeite moeten kosten , if (niet_connected_naar_dat_ding && tijddelta-dat-dat-gebeurde > 1oa_timeout) { 
                 reboot(); }
22:45:40 <@buZz> ofzo
22:53:37 <@r3boot> */5 * * * * sh -c 'ss -nH | grep '1.2.3.4:1883' | grep ESTAB || reboot'
22:53:39 <@r3boot> xoxo
23:12:21 <@buZz> ^_^ ik nam aan dat het geen OS had maar dat kan ook ja
23:30:33 <@FooBar> buZz: de firmware staat online afaik... stuur een PR :)
23:30:48 <@FooBar> en dan nog al die dingen flashen in 't veld ;)
23:35:53 <@FooBar> het was een snell hack destijds... https://github.com/Juerd/hoera10jaar is de code
23:39:07 <@buZz> oja die
23:39:14 <@buZz> nog altijd de hw niet gezien ervan :P

```